### PR TITLE
chore: update gh actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version-file: "package.json"
       - name: Install dependencies
         run: npm ci
       - name: Run Static Analysis
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version-version: "package.json"
       - name: Install dependencies
         run: npm ci
       - name: Install PW browser

--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
     "typescript": "5.5",
     "vite-tsconfig-paths": "^5.0.1"
   },
+  "engines": {
+    "node": "22"
+  },
   "devDependencies": {
     "@eslint/eslintrc": "^3.1.0",
     "@eslint/js": "^9.11.1",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new `engines` field in `package.json` to specify that Node.js version 22 is required for compatibility.
  
- **Bug Fixes**
	- Corrected the Node.js version specification in the CI workflow to dynamically use the version from `package.json` instead of a hardcoded value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->